### PR TITLE
Fix buttons. Fix spacing betweeen main and classes

### DIFF
--- a/components/InfoBox/InfoBox.module.scss
+++ b/components/InfoBox/InfoBox.module.scss
@@ -4,7 +4,6 @@
   position: relative;
   width: 100%;
   margin: 0 auto;
-  z-index: -1;
 }
 
 .scrollHelper {

--- a/components/Navbar/Navbar.module.scss
+++ b/components/Navbar/Navbar.module.scss
@@ -11,6 +11,7 @@
   color: $font-secondary;
   font-size: 1.5rem;
   line-height: 38px;
+  z-index: 10000;
 }
 .navbar__nav {
   height: 100%;

--- a/styles/landingPage.module.scss
+++ b/styles/landingPage.module.scss
@@ -102,11 +102,11 @@
   width: 100%;
   margin: 0 auto;
   position: relative;
-  z-index: -1;
-  margin: 40px 0 20px 0;
+  margin: 60px 0 20px 0;
 }
 
 .classes {
+  margin-top: 20px;
   width: 100%;
   display: grid;
   grid-template-columns: 1.5fr 3fr;


### PR DESCRIPTION
It turns out that if the z-index on classes is -1 you can't click them, but when it's >0 then it covers the navbar. So I changed the z-index on the navbar. That revealed a problem with spacing which I promptly proceeded to mend. Success has been achieved.